### PR TITLE
Generate Bot Placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The bot will always be placed in the middle of the grid, so grid needs to have a
 #### Create Grid Method
 - For each index that's passed into the block, change the element to '-' and times that by the grid_size that's being passed in to ensure it's a square output. (NxN)
 
+#### Place Bot Method
+- To find the center of a square, if you have two coordinates (i.e. a = x/y & b = x/y) you would take the arguments of both corners, put them over two, add each x and each y and then divide by two and that will give you the coordinates of the center. However, since we're just getting passed the argument of the desired grid size, we can divide that number by two, twice, and use the output as the index that will be where `m` should be placed.
+
 ### Bot Movement
 
 ### Path to Princess

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -1,16 +1,22 @@
 class Grid
-  attr_reader :grid
+  attr_reader :grid, :m
+  
   def initialize(grid_size)
     raise ArgumentError.new('Grid Size Must Be An Odd Number, Please Try Again') unless grid_size.odd?
     raise ArgumentError.new('Grid Size Must Be Greater Than 2, Please Try Again') unless grid_size > 2
 
     @grid = Array.new(grid_size)
     create_grid(grid_size)
+    place_bot(grid_size)
   end
 
   def create_grid(grid_size)
-    (3...grid_size).each do |i|
-      grid[i] = '-' * grid_size
+    (0...grid_size).each do |i|
+      @grid[i] = '-' * grid_size
     end
+  end
+
+  def place_bot(grid_size)
+    @grid[(grid_size / 2)][(grid_size / 2)] = 'm'
   end
 end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -19,7 +19,7 @@ describe Grid do
     grid_1 = Grid.new(3)
     grid_2 = Grid.new(5)
 
-    expect(grid_1.grid[1]).to include('-m-')
-    expect(grid_2.grid[2]).to include('-m-')
+    expect(grid_1.grid[1.5][1.5]).to eq('m')
+    expect(grid_2.grid[2.5][2.5]).to eq('m')
   end
 end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -14,4 +14,12 @@ describe Grid do
     expect{ Grid.new(4) }.to raise_error(ArgumentError)
     expect{ Grid.new(1) }.to raise_error(ArgumentError)
   end
+
+  it 'should instantiate with the bot directly in the middle' do
+    grid_1 = Grid.new(3)
+    grid_2 = Grid.new(5)
+
+    expect(grid_1.grid[1]).to include('-m-')
+    expect(grid_2.grid[2]).to include('-m-')
+  end
 end


### PR DESCRIPTION
Changes made to Grid Class
- Initialize calls on `place_bot` method after `create_grid`
- Add `place_bot` method that divides incoming grid_size by 2 to designate middle of board


- [x] Test Coverage 100%

- [x] Updated Readme